### PR TITLE
Update meta.json

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "viam:mlmodelservice-triton-jetpack",
+  "module_id": "viam:mlmodelservice-triton-jetpack",
   "visibility": "public",
   "url": "https://github.com/viamrobotics/viam-mlmodelservice-triton",
   "description": "Viam Triton Inference Server Module for Jetpack",


### PR DESCRIPTION


Name has been deprecated in favor of module_id and will no longer work with the newest versions of the cli
